### PR TITLE
Fix empty requires array bug, allow use of built in PPDs

### DIFF
--- a/process.py
+++ b/process.py
@@ -351,9 +351,18 @@ def fnBuildInstallCommand():
     
     InstallCommandParts = ['/usr/sbin/lpadmin', '-E', '-p', Printer, \
                            '-L', printerLocationQuoted, '-D', \
-                           printerDisplayNameQuoted, '-P', \
-                           '"/Library/Printers/PPDs/Contents/Resources/' + SelectedPPD + '"', \
-                           '-v', DeviceURI]
+                           printerDisplayNameQuoted]
+    
+    # Slightly different options depending on type of PPD
+    if SelectedPPD.endswith('.gz'):      # An installed driver
+        InstallCommandParts.append('-p')                       
+        InstallCommandParts.append('"/Library/Printers/PPDs/Contents/Resources/' + SelectedPPD + '"')
+    if SelectedPPD.endswith('.ppd'):    # Built in generic driver
+        InstallCommandParts.append('-m')
+        InstallCommandParts.append(SelectedPPD)
+
+    InstallCommandParts.append('-v')
+    InstallCommandParts.append(DeviceURI)
     
     for opt in OptionList:  #iterates through option list selections
         InstallCommandParts.append('-o')

--- a/process.py
+++ b/process.py
@@ -395,17 +395,8 @@ def fnMakePkgInfo():
     printerDisplayName = '--displayname=' + PrinterMakeModel + ', ' + PrinterLocation
     printerDescription = '--description=' + PkgInfoDescription
     pkgInfoFileName = PkgInfoName + '-' + PkgInfoVersion + '.plist'
-    if PrinterDriver != '':
-        makePkgInfoCMD = ['/usr/local/munki/makepkginfo', '--unattended_install', \
-                      '--uninstall_method=uninstall_script', \
-                      '--name=' + PkgInfoName, printerDisplayName, printerDescription, \
-                      '--nopkg', '--installcheck_script=installcheck_script.sh', \
-                      '--postinstall_script=postinstall_script.sh', \
-                      '--uninstall_script=uninstall_script.sh', \
-                      '--minimum_os_version=10.6.8', pkgVers, \
-                      "--category=Printers", '-r', PrinterDriver]
-    else:
-        makePkgInfoCMD = ['/usr/local/munki/makepkginfo', '--unattended_install', \
+
+    makePkgInfoCMD = ['/usr/local/munki/makepkginfo', '--unattended_install', \
                       '--uninstall_method=uninstall_script', \
                       '--name=' + PkgInfoName, printerDisplayName, printerDescription, \
                       '--nopkg', '--installcheck_script=installcheck_script.sh', \
@@ -413,6 +404,11 @@ def fnMakePkgInfo():
                       '--uninstall_script=uninstall_script.sh', \
                       '--minimum_os_version=10.6.8', pkgVers, \
                       "--category=Printers"]
+    # Only add the 'requires' key if PrinterDriver has a value
+    if PrinterDriver != '':
+        makePkgInfoCMD.append('-r')
+        makePkgInfoCMD.append(PrinterDriver)        
+        print makePkgInfoCMD
         
     pkginfoOutput = subprocess.Popen(makePkgInfoCMD, \
                                      stdout=subprocess.PIPE, \

--- a/process.py
+++ b/process.py
@@ -395,7 +395,8 @@ def fnMakePkgInfo():
     printerDisplayName = '--displayname=' + PrinterMakeModel + ', ' + PrinterLocation
     printerDescription = '--description=' + PkgInfoDescription
     pkgInfoFileName = PkgInfoName + '-' + PkgInfoVersion + '.plist'
-    makePkgInfoCMD = ['/usr/local/munki/makepkginfo', '--unattended_install', \
+    if PrinterDriver != '':
+        makePkgInfoCMD = ['/usr/local/munki/makepkginfo', '--unattended_install', \
                       '--uninstall_method=uninstall_script', \
                       '--name=' + PkgInfoName, printerDisplayName, printerDescription, \
                       '--nopkg', '--installcheck_script=installcheck_script.sh', \
@@ -403,6 +404,16 @@ def fnMakePkgInfo():
                       '--uninstall_script=uninstall_script.sh', \
                       '--minimum_os_version=10.6.8', pkgVers, \
                       "--category=Printers", '-r', PrinterDriver]
+    else:
+        makePkgInfoCMD = ['/usr/local/munki/makepkginfo', '--unattended_install', \
+                      '--uninstall_method=uninstall_script', \
+                      '--name=' + PkgInfoName, printerDisplayName, printerDescription, \
+                      '--nopkg', '--installcheck_script=installcheck_script.sh', \
+                      '--postinstall_script=postinstall_script.sh', \
+                      '--uninstall_script=uninstall_script.sh', \
+                      '--minimum_os_version=10.6.8', pkgVers, \
+                      "--category=Printers"]
+        
     pkginfoOutput = subprocess.Popen(makePkgInfoCMD, \
                                      stdout=subprocess.PIPE, \
                                      stderr=subprocess.PIPE)

--- a/process.py
+++ b/process.py
@@ -334,7 +334,7 @@ def fnBuildInstallCommand():
     printerDisplayNameQuoted = '"%s"' % (PrinterDisplayName)
     printerLocationQuoted = '"%s"' % (PrinterLocation)
     
-    InstallCommandParts = ['/usr/bin/lpadmin', '-E', '-p', Printer, \
+    InstallCommandParts = ['/usr/sbin/lpadmin', '-E', '-p', Printer, \
                            '-L', printerLocationQuoted, '-D', \
                            printerDisplayNameQuoted, '-P', \
                            '/Library/Printers/PPDs/Contents/Resources/' + SelectedPPD, \

--- a/process.py
+++ b/process.py
@@ -408,7 +408,6 @@ def fnMakePkgInfo():
     if PrinterDriver != '':
         makePkgInfoCMD.append('-r')
         makePkgInfoCMD.append(PrinterDriver)        
-        print makePkgInfoCMD
         
     pkginfoOutput = subprocess.Popen(makePkgInfoCMD, \
                                      stdout=subprocess.PIPE, \

--- a/process.py
+++ b/process.py
@@ -334,11 +334,13 @@ def fnBuildInstallCommand():
     printerDisplayNameQuoted = '"%s"' % (PrinterDisplayName)
     printerLocationQuoted = '"%s"' % (PrinterLocation)
     
+    printerPPD = '/Library/Printers/PPDs/Contents/Resources/' + SelectedPPD
+    printerPPDQuoted = '"%s"' % (printerPPD)
+    
     InstallCommandParts = ['/usr/sbin/lpadmin', '-E', '-p', Printer, \
                            '-L', printerLocationQuoted, '-D', \
                            printerDisplayNameQuoted, '-P', \
-                           '/Library/Printers/PPDs/Contents/Resources/' + SelectedPPD, \
-                           '-v', DeviceURI]
+                           printerPPDQuoted, '-v', DeviceURI]
     
     for opt in OptionList:  #iterates through option list selections
         InstallCommandParts.append('-o')

--- a/process.py
+++ b/process.py
@@ -153,8 +153,11 @@ def fnGetDeviceInformation(SelPrinter):
     global PrinterMakeModel 
     PrinterMakeModel = OptionsList['printer-make-and-model']
     global PrinterLocation
-    PrinterLocation = OptionsList['printer-location']
-    
+    try:
+        PrinterLocation = OptionsList['printer-location']
+    except:
+        PrinterLocation = ""
+        
     if (DeviceURI[:6] == "smb://"):
         global PrintServer
         global PrinterQueue

--- a/process.py
+++ b/process.py
@@ -189,11 +189,17 @@ def fnChoosePPD():
     if (len(ppdSearchTerm) < 1):
         fnChoosePPD()
     
-    cmdPPDSearch = ['/bin/ls', '/Library/Printers/PPDs/Contents/Resources']
+    cmdPPDSearch = ['/usr/sbin/lpinfo', '-m']
     processPPDSearch = subprocess.Popen(cmdPPDSearch, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (ppdListRaw, errorbucket) = processPPDSearch.communicate()
     
-    ppdList = string.split(ppdListRaw, '\n')
+    ppdListRaw = ppdListRaw.split('\n')
+    ppdList = []
+    for ppd in ppdListRaw:
+        if ppd.startswith('drv'):
+            ppdList.append(ppd.split(' ', 1)[0])
+        if ppd.startswith('Library'):
+            ppdList.append(ppd.split('gz ', 1)[0] + 'gz')
     
     foundPPDs = []
     

--- a/supportFiles/postinstall_script.sh
+++ b/supportFiles/postinstall_script.sh
@@ -37,7 +37,7 @@ fi
 <installcommand>
         
 # Enable and start the printers on the system (after adding the printer initially it is paused).
-# /usr/sbin/cupsenable $(lpstat -p | grep -w "printer" | awk '{print$2}')
+/usr/sbin/cupsenable $(lpstat -p | grep -w "printer" | awk '{print$2}')
 
 # Create a receipt for the printer
 mkdir -p /private/etc/cups/deployment/receipts


### PR DESCRIPTION
This code change accomplishes two things : 
1. Bug fix - If you choose to not require a driver package, the pkginfo file was creating a requires array with an empty string.  This created a requirement that Munki could not resolve.  This was fixed by adding a conditional when building the makepkginfo command (lines 422-425)
2. Enhancement - I have some printers that use the built in Generic PCL driver.
   - using /usr/sbin/lpinfo -m  will list installed PPDs as well as the built in ones (line 192)
   - to use the built in PPDs the lpadmin command uses -m instead of -p  (lines 356-362)
